### PR TITLE
labeller: call flag.Parse() and do not log before

### DIFF
--- a/cmd/cpu-node-labeller/cpu-node-labeller.go
+++ b/cmd/cpu-node-labeller/cpu-node-labeller.go
@@ -31,9 +31,11 @@ import (
 )
 
 func main() {
-	glog.Infof("Running cpu-node-labeller")
 	fileName := flag.String("fileName", "cpu-model-nfd-plugin", "file Name")
 	fileDir := flag.String("fileDir", "/etc/kubernetes/node-feature-discovery/source.d/", "file folder")
+	flag.Parse()
+
+	glog.Infof("Running cpu-node-labeller")
 
 	path := filepath.Join(*fileDir, *fileName)
 	filestat, err := os.Stat(path)
@@ -83,4 +85,6 @@ func main() {
 		glog.Fatalf("error while updating node: %s", err)
 		os.Exit(1)
 	}
+
+	glog.Info("updated node!")
 }


### PR DESCRIPTION
We had two bugs in the labeller:
1. flag.Parse() was not called and
2. glog.* functions where called before flag.Parse(), see
https://github.com/golang/glog/blob/master/glog.go#L40

This patch fixes both.

Signed-off-by: Francesco Romani <fromani@redhat.com>